### PR TITLE
Clean scraped files only after zip was created

### DIFF
--- a/download-website
+++ b/download-website
@@ -144,8 +144,8 @@ function zipArchive() {
   // append files from a sub-directory, putting its contents at the root of archive
   archive.directory(output_dir, false);
 
-  archive.finalize();
-
-  console.log(`Removing directory ${output_dir}`)
-  fs.rmdirSync(output_dir, { recursive: true });
+  archive.finalize().then(function(){
+    console.log(`Removing directory ${output_dir}`)
+    fs.rmdirSync(output_dir, { recursive: true });
+  });
 }


### PR DESCRIPTION
Folder with scraped files [will be deleted](https://github.com/smartcatai/website-downloader/blob/6d47bec7732888e748b9b5790d4f956f4b62dd42/download-website#L150) **before** zip-archive is built, which can lead to creating an empty archive.

`archive.finalize()` returns a `Promise`, which means we can perform deletion after all files are properly saved to the archive.